### PR TITLE
Update Project.toml with compat section of julia

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,5 +3,8 @@ uuid = "495a3ad3-8034-41b3-a087-aacf2fd71098"
 authors = ["jaapjong <J.deJong-18@student.tudelft.nl>"]
 version = "0.1.0"
 
+[compat]
+julia = "1.8"
+
 [deps]
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"


### PR DESCRIPTION
The julia package registration rules were not met on the last PR.
There needs go be a section about `[compat]` with a `julia` version.



I took screenshots from the pull request fail message when I tried to register the package.
Url: https://github.com/JuliaRegistries/General/pull/86977

![image](https://github.com/Herb-AI/HerbData.jl/assets/35890341/df0927db-ac92-4354-bfa4-fb5c5dd8247c)

![image](https://github.com/Herb-AI/HerbData.jl/assets/35890341/f58b1b06-d907-421e-988b-db26026db047)
